### PR TITLE
TypeScript inference for array vs single percentile

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -9,7 +9,8 @@ export = percentile;
  *
  * @return {Number|T|Array<Number>|Array<T>}
  */
-declare function percentile<T>(pOrPs: number | Array<number>, list: number[] | TypedArray | T[], fn?: (arg0: T) => number): number | number[] | T | T[];
+declare function percentile<T>(pOrPs: number | [number], list: number[] | TypedArray | T[], fn?: (arg0: T) => number): number | T;
+declare function percentile<T>(pOrPs: Array<number>, list: number[] | TypedArray | T[], fn?: (arg0: T) => number): number[] | T[];
 declare namespace percentile {
     export { TypedArray };
 }


### PR DESCRIPTION
Improves TypeScript inference of return type when the first argument is a number or single-element array.  