### PR TITLE
feat: include types in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.5.0",
   "description": "Calculate a percentile for given array of values",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "files": [
     "lib/"
   ],


### PR DESCRIPTION
this change helps `tsc` pick up the type declarations without a triple-slash directive. See https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package